### PR TITLE
fixed currency converter overlapping issues

### DIFF
--- a/frontend/components/CurrencySelector.tsx
+++ b/frontend/components/CurrencySelector.tsx
@@ -114,22 +114,22 @@ export function CurrencySelector({
   const selectedToken = MENTO_TOKENS[selectedCurrency];
 
   return (
-    <div className={`relative z-[100] ${className}`}>
+    <div className={`relative ${className}`}>
       {/* Currency Selector Button */}
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-between w-full px-4 py-3 bg-slate-800/50 border border-slate-700/50 rounded-lg hover:bg-slate-800/70 transition-colors"
+        className="flex items-center justify-between w-full px-3 sm:px-4 py-3 bg-slate-800/50 border border-slate-700/50 rounded-lg hover:bg-slate-800/70 transition-colors min-h-[60px]"
       >
-        <div className="flex items-center gap-3">
-          <span className="text-2xl">{selectedToken.flag}</span>
-          <div className="text-left">
-            <div className="font-medium text-white">{selectedToken.symbol}</div>
-            <div className="text-xs text-slate-400">{selectedToken.name}</div>
+        <div className="flex items-center gap-2 sm:gap-3 flex-1 min-w-0">
+          <span className="text-xl sm:text-2xl flex-shrink-0">{selectedToken.flag}</span>
+          <div className="text-left min-w-0">
+            <div className="font-medium text-white text-sm sm:text-base">{selectedToken.symbol}</div>
+            <div className="text-xs text-slate-400 truncate">{selectedToken.name}</div>
           </div>
         </div>
         
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-shrink-0">
           {isLoadingRates && <RefreshCw className="w-4 h-4 text-slate-400 animate-spin" />}
           <ChevronDown className={`w-4 h-4 text-slate-400 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
         </div>
@@ -140,10 +140,10 @@ export function CurrencySelector({
         <>
           {/* Backdrop to close dropdown when clicking outside */}
           <div 
-            className="fixed inset-0 z-[90]" 
+            className="fixed inset-0 z-[100]" 
             onClick={() => setIsOpen(false)}
           />
-          <div className="absolute top-full left-0 right-0 mt-2 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-[9999] max-h-80 overflow-y-auto">
+          <div className="absolute top-full left-0 right-0 mt-2 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-[101] max-h-60 sm:max-h-80 overflow-y-auto max-w-full">
           {Object.entries(MENTO_TOKENS).map(([key, token]) => {
             const currency = key as SupportedCurrency;
             const rateInfo = rates.find(r => r.key === currency);
@@ -156,26 +156,26 @@ export function CurrencySelector({
                   onCurrencyChange(currency);
                   setIsOpen(false);
                 }}
-                className={`w-full flex items-center justify-between px-4 py-3 text-left hover:bg-slate-700/50 transition-colors ${
+                className={`w-full flex items-center justify-between px-3 sm:px-4 py-3 text-left hover:bg-slate-700/50 transition-colors ${
                   currency === selectedCurrency ? 'bg-slate-700/30' : ''
                 }`}
               >
-                <div className="flex items-center gap-3">
-                  <span className="text-xl">{token.flag}</span>
-                  <div>
-                    <div className="font-medium text-white">{token.symbol}</div>
-                    <div className="text-xs text-slate-400">{token.name}</div>
+                <div className="flex items-center gap-2 sm:gap-3 flex-1 min-w-0">
+                  <span className="text-lg sm:text-xl flex-shrink-0">{token.flag}</span>
+                  <div className="min-w-0">
+                    <div className="font-medium text-white text-sm sm:text-base">{token.symbol}</div>
+                    <div className="text-xs text-slate-400 truncate">{token.name}</div>
                   </div>
                 </div>
                 
-                <div className="text-right">
+                <div className="text-right flex-shrink-0 ml-2">
                   <div className="text-xs text-slate-400">
                     Balance: {balances[currency]?.formatted ? 
                       parseFloat(balances[currency].formatted).toFixed(2) : 
                       '0.00'}
                   </div>
                   {showConverter && amount && convertedAmounts[currency] && (
-                    <div className="text-sm text-emerald-400">
+                    <div className="text-xs sm:text-sm text-emerald-400">
                       ≈ {parseFloat(convertedAmounts[currency]).toLocaleString()}
                     </div>
                   )}

--- a/frontend/components/modals/CurrencyConverterModal.tsx
+++ b/frontend/components/modals/CurrencyConverterModal.tsx
@@ -105,14 +105,14 @@ export function CurrencyConverterModal({
 
   return (
     <motion.div
-      className="fixed inset-0 bg-slate-900/80 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4 z-50"
+      className="fixed inset-0 bg-slate-900/80 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4 z-[9998]"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.3 }}
     >
       <motion.div
-        className="bg-slate-800/95 backdrop-blur-md border border-slate-700/50 rounded-xl sm:rounded-2xl w-full max-w-md sm:max-w-2xl mx-auto max-h-[95vh] sm:max-h-[90vh] overflow-hidden flex flex-col shadow-2xl shadow-emerald-500/10"
+        className="bg-slate-800/95 backdrop-blur-md border border-slate-700/50 rounded-xl sm:rounded-2xl w-full max-w-xs sm:max-w-md lg:max-w-2xl mx-auto max-h-[95vh] sm:max-h-[90vh] overflow-hidden flex flex-col shadow-2xl shadow-emerald-500/10 relative z-[9999]"
         initial={{ scale: 0.9, y: 20 }}
         animate={{ scale: 1, y: 0 }}
         exit={{ scale: 0.9, y: 20 }}
@@ -177,7 +177,19 @@ export function CurrencyConverterModal({
                     Currency Conversion
                   </h4>
                   
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                  {/* Amount Input */}
+                  <div className="mb-6">
+                    <label className="block text-sm font-medium text-slate-300 mb-2">Amount</label>
+                    <input
+                      type="number"
+                      value={amount}
+                      onChange={(e) => setAmount(e.target.value)}
+                      className="w-full px-4 py-3 bg-slate-800 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:border-emerald-500 focus:outline-none text-lg"
+                      placeholder="Enter amount"
+                    />
+                  </div>
+
+                  <div className="space-y-4 mb-4">
                     <div>
                       <label className="block text-sm font-medium text-slate-300 mb-2">From</label>
                       <CurrencySelector
@@ -187,6 +199,18 @@ export function CurrencyConverterModal({
                         className="bg-slate-800 border-slate-600 text-white focus:border-emerald-500"
                       />
                     </div>
+                    
+                    {/* Swap Button - Centered between selectors */}
+                    <div className="flex justify-center py-2">
+                      <button
+                        onClick={swapCurrencies}
+                        className="p-3 bg-slate-700 hover:bg-slate-600 rounded-full transition-colors border-2 border-slate-600 hover:border-emerald-500 shadow-lg"
+                        title="Swap currencies"
+                      >
+                        <ArrowRightLeft className="w-5 h-5 text-slate-300" />
+                      </button>
+                    </div>
+                    
                     <div>
                       <label className="block text-sm font-medium text-slate-300 mb-2">To</label>
                       <CurrencySelector
@@ -196,28 +220,6 @@ export function CurrencyConverterModal({
                         className="bg-slate-800 border-slate-600 text-white focus:border-emerald-500"
                       />
                     </div>
-                  </div>
-
-                  <div className="mb-4">
-                    <label className="block text-sm font-medium text-slate-300 mb-2">Amount</label>
-                    <input
-                      type="number"
-                      value={amount}
-                      onChange={(e) => setAmount(e.target.value)}
-                      className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:border-emerald-500 focus:outline-none"
-                      placeholder="Enter amount"
-                    />
-                  </div>
-
-                  {/* Swap Button */}
-                  <div className="flex justify-center mb-4">
-                    <button
-                      onClick={swapCurrencies}
-                      className="p-2 bg-slate-700 hover:bg-slate-600 rounded-full transition-colors"
-                      title="Swap currencies"
-                    >
-                      <ArrowRightLeft className="w-4 h-4 text-slate-300" />
-                    </button>
                   </div>
 
                   {/* Conversion Result */}
@@ -276,10 +278,10 @@ export function CurrencyConverterModal({
                     </span>
                   </div>
 
-                  <div className="space-y-3">
+                  <div className="space-y-4">
                     {/* From Currency - Stack Layout */}
-                    <div className="bg-slate-800/50 rounded-lg p-3">
-                      <div className="flex items-center justify-between mb-2">
+                    <div className="bg-slate-800/50 rounded-lg p-4 space-y-4">
+                      <div className="flex items-center justify-between">
                         <label className="text-sm font-medium text-slate-300">From</label>
                         {fromBalance && (
                           <button
@@ -292,13 +294,11 @@ export function CurrencyConverterModal({
                       </div>
                       
                       {/* Currency Selector */}
-                      <div className="mb-3">
-                        <CurrencySelector
-                          selectedCurrency={fromCurrency}
-                          onCurrencyChange={setFromCurrency}
-                          className="bg-slate-700 border-slate-600 text-white focus:border-emerald-500 w-full"
-                        />
-                      </div>
+                      <CurrencySelector
+                        selectedCurrency={fromCurrency}
+                        onCurrencyChange={setFromCurrency}
+                        className="bg-slate-700 border-slate-600 text-white focus:border-emerald-500 w-full"
+                      />
                       
                       {/* Amount Input */}
                       <input
@@ -310,29 +310,27 @@ export function CurrencyConverterModal({
                       />
                     </div>
 
-                    {/* Swap Arrow - Compact */}
-                    <div className="flex justify-center py-1">
+                    {/* Swap Arrow - More Spacing */}
+                    <div className="flex justify-center py-4">
                       <button
                         onClick={swapCurrencies}
-                        className="p-2 bg-slate-700 hover:bg-emerald-600 rounded-full transition-colors border-2 border-slate-600 hover:border-emerald-500"
+                        className="p-3 bg-slate-700 hover:bg-emerald-600 rounded-full transition-colors border-2 border-slate-600 hover:border-emerald-500 shadow-lg"
                         title="Swap currencies"
                       >
-                        <ArrowRightLeft className="w-4 h-4 text-slate-300" />
+                        <ArrowRightLeft className="w-5 h-5 text-slate-300" />
                       </button>
                     </div>
 
                     {/* To Currency - Stack Layout */}
-                    <div className="bg-slate-800/50 rounded-lg p-3">
-                      <label className="block text-sm font-medium text-slate-300 mb-2">To (you receive)</label>
+                    <div className="bg-slate-800/50 rounded-lg p-4 space-y-4">
+                      <label className="block text-sm font-medium text-slate-300">To (you receive)</label>
                       
                       {/* Currency Selector */}
-                      <div className="mb-3">
-                        <CurrencySelector
-                          selectedCurrency={toCurrency}
-                          onCurrencyChange={setToCurrency}
-                          className="bg-slate-700 border-slate-600 text-white focus:border-emerald-500 w-full"
-                        />
-                      </div>
+                      <CurrencySelector
+                        selectedCurrency={toCurrency}
+                        onCurrencyChange={setToCurrency}
+                        className="bg-slate-700 border-slate-600 text-white focus:border-emerald-500 w-full"
+                      />
                       
                       {/* Estimated Amount */}
                       <div className="w-full px-4 py-3 bg-slate-700 border border-slate-600 rounded-lg">


### PR DESCRIPTION
 1. Z-index Conflicts

  - Updated modal backdrop z-index from z-50 to z-[9998]
  - Updated modal container z-index to z-[9999]
  - Adjusted CurrencySelector dropdown z-index to z-[101]
  with backdrop at z-[100]

  2. Currency Selector Layout Overlapping

  - Conversion View: Changed from side-by-side grid layout
   to stacked layout with proper spacing
  - Swap View: Increased padding and spacing between
  From/To currency sections
  - Added space-y-4 for consistent vertical spacing

  3. Swap Button Positioning

  - Moved swap button between From/To selectors with
  better visual separation
  - Increased button size (p-3 instead of p-2) and added
  border/shadow effects
  - Added py-4 spacing around the swap button for clear
  separation

  4. Mobile Responsiveness

  - Modal Width: Adjusted from max-w-md sm:max-w-2xl to
  max-w-xs sm:max-w-md lg:max-w-2xl
  - Currency Selector Button: Added responsive padding
  (px-3 sm:px-4) and minimum height
  - Dropdown Items: Improved text sizing and spacing for
  mobile screens
  - Dropdown Height: Reduced on mobile (max-h-60 
  sm:max-h-80)

  5. Content Layout Improvements

  - Amount Input: Moved to the top of conversion view for
  better UX
  - Spacing: Changed from mb-3 to space-y-4 for consistent
   gaps
  - Flexbox: Added flex-1 min-w-0 and flex-shrink-0 for
  better text truncation
  - Text Sizing: Made responsive with text-sm sm:text-base
   patterns